### PR TITLE
FIX: deprecated CSS classes usage

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,10 +77,10 @@ exports.decorateConfig = config => {
 		],
 		termCSS: `
 			${config.termCSS || ''}
-			x-screen a {
+			.terminal a {
 		    color: ${linkColor};
 		  }
-			::selection {
+			.terminal .xterm-selection div {
 			  background: ${selectionColor};
 			}
 		`


### PR DESCRIPTION
correcting error in file bundle.js:1 Warning: "hyper-popping-and-locking" plugin uses some deprecated CSS classes (x-screen, ::selection).

ISSUE: hyper-popping-and-locking uses some deprecated CSS classes #1